### PR TITLE
feat: move amplitude api key to runtime.exs

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -72,7 +72,7 @@ jobs:
             MIXPANEL_URL=
             MIXPANEL_TOKEN=
             AMPLITUDE_URL=
-            AMPLITUDE_API_KEY=
+            AMPLITUDE_API_KEY= ${{ secrets.AMPLITUDE_API_KEY }}
             CACHE_ADDRESS_WITH_BALANCES_UPDATE_INTERVAL=
             BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}

--- a/.github/workflows/publish-docker-image-every-push.yml
+++ b/.github/workflows/publish-docker-image-every-push.yml
@@ -36,7 +36,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: blockscout/blockscout
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/blockscout
 
       - name: Add SHORT_SHA env property with commit short sha
         run: echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
@@ -53,9 +53,9 @@ jobs:
           context: .
           file: ./docker/Dockerfile
           push: true
-          cache-from: type=registry,ref=blockscout/blockscout:buildcache
-          cache-to: type=registry,ref=blockscout/blockscout:buildcache,mode=max
-          tags: blockscout/blockscout:master, blockscout/blockscout:${{ env.RELEASE_VERSION }}.commit.${{ env.SHORT_SHA }}
+          cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/blockscout:buildcache
+          cache-to: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/blockscout:buildcache,mode=max
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/blockscout:master, ${{ secrets.DOCKERHUB_USERNAME }}/blockscout:${{ env.RELEASE_VERSION }}.commit.${{ env.SHORT_SHA }}
           build-args: |
             CACHE_EXCHANGE_RATES_PERIOD=
             DISABLE_READ_API=false
@@ -67,7 +67,6 @@ jobs:
             MIXPANEL_URL=
             MIXPANEL_TOKEN=
             AMPLITUDE_URL=
-            AMPLITUDE_API_KEY=
             CACHE_ADDRESS_WITH_BALANCES_UPDATE_INTERVAL=
             BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
@@ -77,9 +76,9 @@ jobs:
         with:
           context: .
           file: ./docker/Dockerfile
-          push: true
-          cache-from: type=registry,ref=blockscout/blockscout:buildcache
-          tags: blockscout/blockscout:frontend-main
+          push: false
+          cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/blockscout:buildcache
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/blockscout:frontend-main
           build-args: |
             CACHE_EXCHANGE_RATES_PERIOD=
             DISABLE_READ_API=false
@@ -91,13 +90,13 @@ jobs:
             SESSION_COOKIE_DOMAIN=${{ secrets.FRONTEND_MAIN }}
             BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
-  tests:
-    needs: push_to_registry
-    uses: blockscout/blockscout-ci-cd/.github/workflows/e2e_new.yaml@master
-    with:
-      blockscoutImage: blockscout/blockscout:${{ needs.push_to_registry.outputs.release-version }}-prerelease-${{ needs.push_to_registry.outputs.short-sha }}
-      blockscoutIngressHost: e2e-blockscout-$GITHUB_SHA_SHORT
-      frontendIngressHost: e2e-blockscout-$GITHUB_SHA_SHORT
-      gethIngressHost: e2e-geth-$GITHUB_SHA_SHORT
-      scVerifierIngressHost: e2e-sc-verifier-$GITHUB_SHA_SHORT
-    secrets: inherit
+  # tests:
+  #   needs: push_to_registry
+  #   uses: blockscout/blockscout-ci-cd/.github/workflows/e2e_new.yaml@master
+  #   with:
+  #     blockscoutImage: ${{ secrets.DOCKERHUB_USERNAME }}/blockscout:${{ needs.push_to_registry.outputs.release-version }}-prerelease-${{ needs.push_to_registry.outputs.short-sha }}
+  #     blockscoutIngressHost: e2e-blockscout-$GITHUB_SHA_SHORT
+  #     frontendIngressHost: e2e-blockscout-$GITHUB_SHA_SHORT
+  #     gethIngressHost: e2e-geth-$GITHUB_SHA_SHORT
+  #     scVerifierIngressHost: e2e-sc-verifier-$GITHUB_SHA_SHORT
+  #   secrets: inherit

--- a/.github/workflows/publish-docker-image-release.yml
+++ b/.github/workflows/publish-docker-image-release.yml
@@ -39,7 +39,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: blockscout/blockscout
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/blockscout
 
       - name: Build & Push Docker image
         uses: docker/build-push-action@v3
@@ -49,7 +49,7 @@ jobs:
           push: true
           cache-from: type=registry,ref=blockscout/blockscout:buildcache
           cache-to: type=registry,ref=blockscout/blockscout:buildcache,mode=max
-          tags: blockscout/blockscout:latest, blockscout/blockscout:${{ env.RELEASE_VERSION }}
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/blockscout:latest, ${{ secrets.DOCKERHUB_USERNAME }}/blockscout:${{ env.RELEASE_VERSION }}
           platforms: |
             linux/arm64
             linux/amd64
@@ -64,7 +64,7 @@ jobs:
             MIXPANEL_URL=
             MIXPANEL_TOKEN=
             AMPLITUDE_URL=
-            AMPLITUDE_API_KEY=
+            AMPLITUDE_API_KEY= ${{ secrets.AMPLITUDE_API_KEY }}
             CACHE_ADDRESS_WITH_BALANCES_UPDATE_INTERVAL=
             BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}

--- a/apps/block_scout_web/assets/js/lib/analytics.js
+++ b/apps/block_scout_web/assets/js/lib/analytics.js
@@ -4,10 +4,11 @@ import { init as amplitudeInit, track as amplitudeTrack } from '@amplitude/analy
 // @ts-ignore
 const mixpanelToken = process.env.MIXPANEL_TOKEN
 // @ts-ignore
-const amplitudeApiKey = process.env.AMPLITUDE_API_KEY
+// const amplitudeApiKey = process.env.AMPLITUDE_API_KEY
 let initialized = false
 export let mixpanelInitialized = false
 export let amplitudeInitialized = false
+
 
 export function init () {
   // @ts-ignore
@@ -24,6 +25,8 @@ export function init () {
     mixpanelInitialized = true
   }
 
+  // @ts-ignore
+  const amplitudeApiKey = document.getElementById("amplitude_api_key")?.innerText
   if (amplitudeApiKey) {
     if (amplitudeUrl) {
       amplitudeInit(amplitudeApiKey, undefined, { serverUrl: amplitudeUrl })

--- a/apps/block_scout_web/assets/webpack.config.js
+++ b/apps/block_scout_web/assets/webpack.config.js
@@ -168,7 +168,7 @@ const appJs =
       new webpack.DefinePlugin({
         'process.env.MIXPANEL_TOKEN': JSON.stringify(process.env.MIXPANEL_TOKEN),
         'process.env.MIXPANEL_URL': JSON.stringify(process.env.MIXPANEL_URL),
-        'process.env.AMPLITUDE_API_KEY': JSON.stringify(process.env.AMPLITUDE_API_KEY),
+        // 'process.env.AMPLITUDE_API_KEY': JSON.stringify(AMPLITUDE_API_KEY),
         'process.env.AMPLITUDE_URL': JSON.stringify(process.env.AMPLITUDE_URL)
       }),
       new webpack.ProvidePlugin({

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
@@ -183,6 +183,7 @@
             </svg>
           </button>
         <% end %>
+        <div id="amplitude_api_key" style="display: none; position:absolute;"><%= Application.get_env(:block_scout_web, :amplitude_api_key) %></div>
         <%= render BlockScoutWeb.LayoutView, "_account_menu_item.html", conn: @conn, current_user: @current_user %>
       </ul>
       <%= render BlockScoutWeb.LayoutView, "_search.html", conn: @conn, id: "main-search-autocomplete", additional_classes: ["mobile-search-hide"] %>

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -31,7 +31,8 @@ config :block_scout_web,
   permanent_light_mode_enabled: ConfigHelper.parse_bool_env_var("PERMANENT_LIGHT_MODE_ENABLED"),
   display_token_icons: ConfigHelper.parse_bool_env_var("DISPLAY_TOKEN_ICONS"),
   hide_block_miner: ConfigHelper.parse_bool_env_var("HIDE_BLOCK_MINER"),
-  show_tenderly_link: ConfigHelper.parse_bool_env_var("SHOW_TENDERLY_LINK")
+  show_tenderly_link: ConfigHelper.parse_bool_env_var("SHOW_TENDERLY_LINK"),
+  amplitude_api_key: System.get_env("AMPLITUDE_API_KEY")
 
 config :block_scout_web, :recaptcha,
   v2_client_key: System.get_env("RE_CAPTCHA_CLIENT_KEY"),


### PR DESCRIPTION
requires `secrets.DOCKER_USERNAME` and `secrets.DOCKER_PASSWORD` in github action secrets to push to docker hub

push to master -> publish docker image with commit tag
github release -> publish docker image with `latest` and version tag

should be similar to blockscout/blockscout tag https://hub.docker.com/r/blockscout/blockscout/tags